### PR TITLE
rustsbi-k510: remove legacy features

### DIFF
--- a/rustsbi-k510/Cargo.toml
+++ b/rustsbi-k510/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustsbi = { version = "0.3.0-alpha.4", features = ["legacy"] }
+rustsbi = "0.3.0-alpha.4"
 riscv = "0.9.0"
 spin = "0.9"
 r0 = "1"

--- a/rustsbi-k510/src/ns16550a.rs
+++ b/rustsbi-k510/src/ns16550a.rs
@@ -1,7 +1,8 @@
-use core::fmt::Write;
-use rustsbi::legacy_stdio::LegacyStdio;
-use spin::Mutex;
+use core::fmt;
+use spin::{once::Once, Mutex};
 use uart_16550::MmioSerialPort;
+
+pub(crate) static SERIAL: Once<Ns16550a> = Once::new();
 
 pub(crate) struct Ns16550a(Mutex<MmioSerialPort>);
 
@@ -11,16 +12,38 @@ impl Ns16550a {
     }
 }
 
-impl LegacyStdio for Ns16550a {
-    fn getchar(&self) -> u8 {
-        self.0.lock().receive()
-    }
+struct Stdout;
 
-    fn putchar(&self, ch: u8) {
-        self.0.lock().send(ch);
+impl fmt::Write for Stdout {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        if let Some(serial) = SERIAL.get() {
+            let mut serial = serial.0.lock();
+            for byte in s.as_bytes() {
+                serial.send(*byte)
+            }
+        }
+        Ok(())
     }
+}
 
-    fn write_str(&self, s: &str) {
-        self.0.lock().write_str(s).unwrap();
+#[inline]
+#[doc(hidden)]
+pub fn _print(args: fmt::Arguments) {
+    use fmt::Write;
+    Stdout.write_fmt(args).unwrap();
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! print {
+    ($($arg:tt)*) => ($crate::ns16550a::_print(core::format_args!($($arg)*)));
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! println {
+    () => ($crate::print!("\r\n"));
+    ($($arg:tt)*) => {
+        $crate::ns16550a::_print(core::format_args!($($arg)*));
+        $crate::print!("\r\n");
     }
 }


### PR DESCRIPTION
they are deprecated and should not exist on newer designs

一些说明：SBI接口的“legacy”部分都是应该被删除的，为什么qemu的实现保留了呢？因为很多内核教程作者觉得这个接口很容易调试，从未入门内核开发的人很容易学习，即使长期的工程实践认为它是废弃设计。k510作为实际的产品，不能保留废弃的接口，以免影响性能。